### PR TITLE
Fix option '6' in opts arg

### DIFF
--- a/src/vcmipidemo.c
+++ b/src/vcmipidemo.c
@@ -638,7 +638,7 @@ int  change_options_by_commandline(int argc, char *argv[], int *shutter, int *ga
 
 	cfgWB->mode = WBMODE_INACTIVE;
 
-	while((opt =  getopt(argc, argv, "abfnopx46:d:g:i:r:s:w:y:")) != -1)
+	while((opt =  getopt(argc, argv, "abfnopx46d:g:i:r:s:w:y:")) != -1)
 	{
 		switch(opt)
 		{


### PR DESCRIPTION
Option '6' does not require an argument,
yet the getopt string indicated that it did require an argument.